### PR TITLE
Fixed 404 page to work with local jekyll server

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Page not found
+permalink: 404.html
 ---
 
 Ups... Something went wrong. Go back to the Home Page and start over!


### PR DESCRIPTION
Currently, previewing a site with `jekyll serve` using this theme won't properly serve up the 404 page. I changed the file `404.md` to specify the permalink `404.html` to fix this issue (per the instructions [here](https://jekyllrb.com/tutorials/custom-404-page/)).