### PR TITLE
Fixed gulp-responsive image enlargement error for small images

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -199,6 +199,7 @@ gulp.task('img', function() {
       quality: 70,
       progressive: true,
       withMetadata: false,
+      errorOnEnlargement: false,
     }))
     .pipe(imagemin())
     .pipe(gulp.dest('assets/img/posts/'));


### PR DESCRIPTION
Currently, gulp-responsive will fail on running `gulp img` when images smaller than 1999px are placed in the folder `_img/posts`, throwing the following error
```
events.js:167
      throw er; // Unhandled 'error' event
      ^
vips warning: Error: File `<file_name>`: Image enlargement is detected
  real width: 1237px, required width: 1999px
VipsJpeg: error reading resolution
vips warning: VipsJpeg: error reading resolution

(sharp:4339): GLib-CRITICAL **: g_hash_table_lookup: assertion 'hash_table != NULL' failed

(sharp:4339): GLib-CRITICAL **: g_hash_table_lookup: assertion 'hash_table != NULL' failed

(sharp:4339): GLib-CRITICAL **: g_hash_table_insert_internal: assertion 'hash_table != NULL' failed

(sharp:4339): GLib-CRITICAL **: g_hash_table_lookup: assertion 'hash_table != NULL' failed
Segmentation fault (core dumped)
```
Error fixed with the suggestion from [this thread](https://github.com/mahnunchik/gulp-responsive/issues/69), adding the `errorOnEnlargement: false` option to the `img` gulp task.