### PR TITLE
alternative for gulp

### DIFF
--- a/resizing-images/README.md
+++ b/resizing-images/README.md
@@ -15,3 +15,9 @@ Now, whenever you create a new post:
 3. Done
 
 It will create a new folder called `resized` contains all resized-named images (i.e, `*_lg.jpg`, `*_md.jpg`, `*_placehold.jpg`,...) for your post.
+
+The remain thing to do is to copy the resized-named images to `assets/img/posts/`
+
+Note that: in the markdown file of your post, `featured-img` should contains the extendsion.
+
+For example: `featured-img: sky.jpg`

--- a/resizing-images/README.md
+++ b/resizing-images/README.md
@@ -1,0 +1,11 @@
+# Using
+
+Make sure `sudo chmod 777 resize.sh` (Only need once for the first time)
+
+Whenever you create a new post:
+
+1. Put the featured image in the same folder with `resize.sh`
+2. Run `./resize.sh`
+3. Done
+
+It will create a new folder called `resized` contains all resized-named images (i.e, `*_lg.jpg`, `*_md.jpg`, `*_placehold.jpg`,...) for your post.

--- a/resizing-images/README.md
+++ b/resizing-images/README.md
@@ -1,8 +1,14 @@
+# Purpose
+
+A simple alternative for `gulp` in case you can not use `gulp`.
+
 # Using
 
-Make sure `sudo chmod 777 resize.sh` (Only need once for the first time)
+Install `ImageMagick` by running the command `sudo apt-get install imagemagick`
 
-Whenever you create a new post:
+In the folder `resizing-image`, run `sudo chmod 777 resize.sh` (Only need once for the first time)
+
+Now, whenever you create a new post:
 
 1. Put the featured image in the same folder with `resize.sh`
 2. Run `./resize.sh`

--- a/resizing-images/resize.sh
+++ b/resizing-images/resize.sh
@@ -1,0 +1,4 @@
+mkdir ./resized/; 
+for photos in *.jpg *.png *.jpeg; 
+do convert -verbose $photos -background white -flatten -resize 2000 ./resized/$photos.jpg && convert -verbose $photos -background white -flatten -resize 2000 ./resized/$photos\_lg.jpg && convert -verbose $photos -background white -flatten -resize 1000 ./resized/$photos\_md.jpg && convert -verbose $photos -background white -flatten -resize 768 ./resized/$photos\_sm.jpg && convert -verbose $photos -background white -flatten -resize 575 ./resized/$photos\_xs.jpg && convert -verbose $photos -background white -flatten -resize 256 ./resized/$photos\_placehold.jpg && convert -verbose $photos -background white -flatten -resize 535 ./resized/$photos\_thumb.jpg && convert -verbose $photos -background white -flatten -resize 1070 ./resized/$photos\_thumb@2x.jpg; 
+done


### PR DESCRIPTION
`gulp` does not work for me in proper way. This is an alternative for `gulp` to resize and name the featured images automatically. Just run the script, then copy the generated images to `assets/img/posts`.