### PR TITLE
fix img tag in card.html

### DIFF
--- a/_includes/card.html
+++ b/_includes/card.html
@@ -12,7 +12,7 @@
     {% if post.featured-img %}
       <figure class="post-card__thumb">
         <img
-          src="{{ site.url }}{{ site.baseurl }}/assets/img/posts/{{post.featured-img}}_placehold.jpg",
+          src="{{ site.url }}{{ site.baseurl }}/assets/img/posts/{{post.featured-img}}_placehold.jpg"
           data-srcset="{{ site.url }}{{ site.baseurl }}/assets/img/posts/{{post.featured-img}}_thumb.jpg, {{ site.url }}{{ site.baseurl }}/assets/img/posts/{{post.featured-img}}_thumb@2x.jpg 2x"
           class="lazyload blur"
           alt="{{post.title}}"


### PR DESCRIPTION
Hi,

great theme! I've started using it for my personal website :)
I just found a small bug in the `card.html` file - there was a comma added, that for some strange reason doesn't affect the HTML element when it's used on the main page, but when I tried to use it on a subpage, the `img` tag was not correctly rendered:

![screenshot 2018-12-21 at 22 34 48](https://user-images.githubusercontent.com/4835412/50364544-b99c1200-0570-11e9-9b89-9f01e92e07ff.png)
