### PR TITLE
Update to Jekyll 4.0

### DIFF
--- a/jekyll-sleek.gemspec
+++ b/jekyll-sleek.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.3"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.1"
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler", ">= 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
With Jekyll >= 4.0 `bundle install` doesn't work
```
Fetching gem metadata from https://rubygems.org/...........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.12) x64-mingw32

  Current Bundler version:
    bundler (2.1.4)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 1.12)' in any of the relevant sources:
  the local ruby installation
```

This can be solved by replacing `~>` with `>=` for the bundler dependency in `jekyll-sleek.gemspec`