### PR TITLE
Post authors

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -40,6 +40,9 @@ layout: compress
       {% endif %}
       <h1 class="hero__title">{{ page.title }}</h1>
       <p class="hero__meta">
+        {% if page.author %}
+        <span>{{ page.author }}&nbsp;&middot;</span>
+        {% endif %}
         <span>
           <time>{{ page.date | date_to_string }}</time>&nbsp;&middot;
         </span>

--- a/_posts/2017-10-15-markdown-cheatsheet.md
+++ b/_posts/2017-10-15-markdown-cheatsheet.md
@@ -4,6 +4,7 @@ title: Markdown Cheatsheet
 summary: Markdown is a way to style text on the web. You control the display of the document; formating words as bold or italic, adding images, and creating lists are just a few of the things we can do with Markdown. Mostly, Markdown is just regular text with a few non-alphabetic characters thrown in.
 featured-img: emile-perron-190221
 categories: Guides
+author: <A href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet" target="blank">adam-p</a>
 ---
 
 From [adam-p/markdown-here](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)

--- a/_posts/2017-11-26-getting-started.md
+++ b/_posts/2017-11-26-getting-started.md
@@ -3,6 +3,7 @@ layout: post
 title: Getting Started with Sleek
 featured-img: sleek
 mathjax: true
+author: Jan Czizikow
 ---
 
 # Getting started


### PR DESCRIPTION
Added a few lines in `post.html` to add post author if it exists.
Added authors to posts: **Getting Started with Sleek** and **Markdown Cheatsheet** as an example.
*The authors can also link into their profiles (Markdown Cheatsheet). It can be further improved if allowed.*